### PR TITLE
Verify client certificates on the backend

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -66,7 +66,7 @@ func main() {
 	tlsConfig := &tls.Config{
 		GetCertificate: certificate.GetCertificate,
 		RootCAs:        certPool,
-		ClientAuth:     tls.RequireAnyClientCert,
+		ClientAuth:     tls.RequireAndVerifyClientCert,
 	}
 
 	authorizedAppGuidList := os.Getenv("AUTHORIZED_APP_GUIDS")


### PR DESCRIPTION
tls.RequireAnyClientCert does not verify client certificates again the root certificate. As a result an unauthorized app could generate a self-signed certificate with a authorised GUID in the CN field and trick this backend into accepting connections from it.